### PR TITLE
added tag path to estimateSpawnLoc

### DIFF
--- a/R/estimateSpawnLoc.R
+++ b/R/estimateSpawnLoc.R
@@ -26,12 +26,20 @@ estimateSpawnLoc = function(capHist_proc = NULL) {
   capHist_proc = capHist_proc %>%
     filter(UserProcStatus)
 
+  # create tag_path field for each tag
+  tag_path <- capHist_proc %>%
+    select(TagID, Node) %>%
+    group_by(TagID) %>%
+    summarise(TagPath = toString(Node)) %>%
+    ungroup()
+
   finalLoc = capHist_proc %>%
     group_by(TagID) %>%
     filter(NodeOrder == max(NodeOrder)) %>%
     slice(1) %>%
     ungroup() %>%
-    select(TagID, ObsDate, BranchNum, Group, SiteID, Node)
+    select(TagID, ObsDate, BranchNum, Group, SiteID, Node) %>%
+    full_join(tag_path)
 
   return(finalLoc)
 


### PR DESCRIPTION
created a character string of valid nodes that a tag was observed at and included it in the final output data frame of final spawn location. 