### PR TITLE
comment out a filter on the UserProcStatus field

### DIFF
--- a/R/estimateSpawnLoc.R
+++ b/R/estimateSpawnLoc.R
@@ -24,8 +24,8 @@ estimateSpawnLoc = function(capHist_proc = NULL) {
            UserProcStatus = as.logical(UserProcStatus))
 
   # filter for observations that should be kept
-  capHist_proc = capHist_proc %>%
-    filter(UserProcStatus)
+  #capHist_proc = capHist_proc %>%
+  #  filter(UserProcStatus)
 
   # create tag_path field for each tag
   tag_path <- capHist_proc %>%


### PR DESCRIPTION
The estimateSpawnLoc fun was internally filtering the proc_ch by the UserProcStatus field without the user knowing.  I commented out the filter, so now all the tags and observations in the proc_ch file supplied to the function get returned. 